### PR TITLE
Relax version constraints on sdl2

### DIFF
--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -48,7 +48,7 @@ library
 
   build-depends:
     base == 4.*,
-    sdl2 == 1.1.*
+    sdl2 == 1.3.*
 
   default-language:
     Haskell2010
@@ -68,7 +68,7 @@ test-suite test-sdl2-image
 
   build-depends:
     base == 4.*,
-    sdl2 == 1.1.*,
+    sdl2 == 1.3.*,
     sdl2-image == 0.2.*,
     HUnit == 1.2.*,
     hspec == 1.11.*

--- a/sdl2-image.cabal
+++ b/sdl2-image.cabal
@@ -48,7 +48,7 @@ library
 
   build-depends:
     base == 4.*,
-    sdl2 == 1.3.*
+    sdl2 >= 1.1 && < 1.4
 
   default-language:
     Haskell2010
@@ -68,7 +68,7 @@ test-suite test-sdl2-image
 
   build-depends:
     base == 4.*,
-    sdl2 == 1.3.*,
+    sdl2 >= 1.1 && < 1.4,
     sdl2-image == 0.2.*,
     HUnit == 1.2.*,
     hspec == 1.11.*


### PR DESCRIPTION
Update to work with the latest version of `sdl2` which is 1.3.0